### PR TITLE
use a factory to generate better types

### DIFF
--- a/src/box.tsx
+++ b/src/box.tsx
@@ -1,38 +1,44 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {BoxProps} from './types/box-types'
+import {Is, BoxProps, BoxComponent} from './types/box-types'
 import {propTypes} from './enhancers'
 import enhanceProps from './enhance-props'
 
-export default class Box extends React.Component<BoxProps, {}> {
-  static displayName = 'Box'
+type Options<T extends Is> = {
+  is: T
+}
 
-  static propTypes = {
-    ...propTypes,
-    innerRef: PropTypes.func,
-    is: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-    boxSizing: propTypes.boxSizing
-  }
-
-  static defaultProps = {
-    innerRef: null,
-    is: 'div',
-    boxSizing: 'border-box'
-  }
-
-  render() {
-    const {is = 'div', innerRef, children, ...props} = this.props
+function createComponent<T extends Is>({ is: defaultIs }: Options<T>) {
+  const Component: BoxComponent<T> = ({ is = defaultIs, innerRef, children, ...props }: BoxProps<T>) => {
     // Convert the CSS props to class names (and inject the styles)
     const {className, enhancedProps: parsedProps} = enhanceProps(props)
 
     parsedProps.className = className
 
     if (innerRef) {
-      parsedProps.ref = (node: React.ReactNode) => {
-        innerRef(node)
-      }
+      parsedProps.ref = innerRef
     }
 
     return React.createElement(is, parsedProps, children)
   }
+
+  ;(Component as any).displayName = 'Box'
+
+  ;(Component as any).propTypes = {
+    ...propTypes,
+    innerRef: PropTypes.func,
+    is: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+  }
+
+  ;(Component as any).defaultProps = {
+    innerRef: null,
+    is: 'div',
+    boxSizing: 'border-box'
+  }
+
+  return Component
 }
+
+const Box = createComponent({ is: 'div' })
+
+export default Box

--- a/src/enhance-props.ts
+++ b/src/enhance-props.ts
@@ -2,19 +2,22 @@ import {propEnhancers} from './enhancers'
 import expandAliases from './expand-aliases'
 import * as cache from './cache'
 import * as styles from './styles'
-import {BoxProps} from './types/box-types'
+import {Without} from './types/box-types'
 import {EnhancerProps} from './types/enhancers'
+
+type PreservedProps = Without<React.ComponentProps<any>, keyof EnhancerProps>
 
 interface EnhancedPropsResult {
   className: string
-  enhancedProps: BoxProps
+  enhancedProps: PreservedProps
 }
+
 /**
  * Converts the CSS props to class names and inserts the styles.
  */
 export default function enhanceProps(rawProps: EnhancerProps & React.ComponentPropsWithoutRef<any>): EnhancedPropsResult {
   const propsMap = expandAliases(rawProps)
-  const enhancedProps: BoxProps = {}
+  const preservedProps: PreservedProps = {}
   let className = rawProps.className || ''
 
   for (const [propName, propValue] of propsMap) {
@@ -34,7 +37,7 @@ export default function enhanceProps(rawProps: EnhancerProps & React.ComponentPr
       continue
     } else if (!enhancer) {
       // Pass through native props. e.g: disabled, value, type
-      enhancedProps[propName] = propValue
+      preservedProps[propName] = propValue
       continue
     }
 
@@ -49,5 +52,5 @@ export default function enhanceProps(rawProps: EnhancerProps & React.ComponentPr
 
   className = className.trim()
 
-  return {className, enhancedProps}
+  return {className, enhancedProps: preservedProps}
 }

--- a/src/types/box-types.ts
+++ b/src/types/box-types.ts
@@ -5,7 +5,7 @@ import { EnhancerProps } from './enhancers'
  * @template T Object
  * @template K Union of T keys
  */
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+export type Without<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
 /**
  * "is" prop
@@ -19,7 +19,7 @@ export type Is<P = any> = React.ElementType<P>
  * @template T React component or string element
  */
 export type BoxProps<T extends Is> = &
-  Omit<React.ComponentProps<T>, "is"> &
+  Without<React.ComponentProps<T>, "is"> &
   EnhancerProps & {
     /**
      * Replaces the underlying element

--- a/src/types/box-types.ts
+++ b/src/types/box-types.ts
@@ -1,22 +1,44 @@
-import {ReactNode} from 'react'
+import React from 'react'
 import { EnhancerProps } from './enhancers'
 
-export type BoxProps = EnhancerProps & {
-  /**
-   * Lets you change the underlying element type. You can pass either a
-   * string to change the DOM element type, or a React component type to
-   * inherit another component. The component just needs to accept a
-   * `className` prop to work. A good example is inheriting the react-router
-   * `Link` component.
-   */
-  is?: keyof JSX.IntrinsicElements | React.ComponentClass<any, any> | React.FunctionComponent<any>
+/**
+ * @template T Object
+ * @template K Union of T keys
+ */
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
-  /**
-   * Callback that gets passed a ref to inner DOM node (or component if the
-   * `is` prop is set to a React component type).
-   */
-  innerRef?(ref: ReactNode): void
+/**
+ * "is" prop
+ * @template P Props
+ */
+export type Is<P = any> = React.ElementType<P>
 
-  /** We need this for now to pass arbitrary props to the `is` Component until we can get a proper generic written */
-  [key: string]: any
+/**
+ * Generic component props with "is" prop
+ * @template P Additional props
+ * @template T React component or string element
+ */
+export type BoxProps<T extends Is> = &
+  Omit<React.ComponentProps<T>, "is"> &
+  EnhancerProps & {
+    /**
+     * Replaces the underlying element
+     */
+    is?: T
+
+    /**
+     * Callback that gets passed a ref to inner DOM node (or component if the
+     * `is` prop is set to a React component type).
+     */
+    innerRef?: React.Ref<T>
+  }
+
+export interface BoxComponent<T extends Is> {
+  // This is the desired type (inspired by reakit)
+  // <TT extends Is = T>(props: BoxProps<TT>): JSX.Element
+  // Unfortunately, TypeScript doesn't like it. It works for string elements
+  // and functional components without generics, but it breaks on generics.
+  // The following two types are a workaround.
+  <TT extends Is>(props: BoxProps<TT> & { is?: TT }): React.ReactElement | null
+  (props: BoxProps<T>): React.ReactElement | null
 }


### PR DESCRIPTION
This PR introduces a better generic for the Box component (and switches it to a `React.FunctionComponent` albeit loosely typed).

The idea is that we can _infer_ the props based on the `is` prop (when provided).

<img width="510" alt="Screen Shot 2019-05-22 at 1 22 55 PM" src="https://user-images.githubusercontent.com/710752/58199185-8a134200-7c95-11e9-8f56-7b1d49c689eb.png">
<img width="637" alt="Screen Shot 2019-05-22 at 1 21 47 PM" src="https://user-images.githubusercontent.com/710752/58199186-8aabd880-7c95-11e9-962b-67c676e2e864.png">
<img width="1118" alt="Screen Shot 2019-05-22 at 1 21 33 PM" src="https://user-images.githubusercontent.com/710752/58199188-8aabd880-7c95-11e9-89f6-bf80ff1fae0b.png">
<img width="937" alt="Screen Shot 2019-05-22 at 1 21 25 PM" src="https://user-images.githubusercontent.com/710752/58199189-8aabd880-7c95-11e9-89d6-07e151b97098.png">
