### PR TITLE
improve ts errors for `is` props

### DIFF
--- a/src/box.tsx
+++ b/src/box.tsx
@@ -1,44 +1,34 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {Is, BoxProps, BoxComponent} from './types/box-types'
+import {BoxComponent} from './types/box-types'
 import {propTypes} from './enhancers'
 import enhanceProps from './enhance-props'
 
-type Options<T extends Is> = {
-  is: T
+const Box: BoxComponent = ({ is = 'div', innerRef, children, ...props }) => {
+  // Convert the CSS props to class names (and inject the styles)
+  const {className, enhancedProps: parsedProps} = enhanceProps(props)
+
+  parsedProps.className = className
+
+  if (innerRef) {
+    parsedProps.ref = innerRef
+  }
+
+  return React.createElement(is, parsedProps, children)
 }
 
-function createComponent<T extends Is>({ is: defaultIs }: Options<T>) {
-  const Component: BoxComponent<T> = ({ is = defaultIs, innerRef, children, ...props }: BoxProps<T>) => {
-    // Convert the CSS props to class names (and inject the styles)
-    const {className, enhancedProps: parsedProps} = enhanceProps(props)
+Box.displayName = 'Box'
 
-    parsedProps.className = className
-
-    if (innerRef) {
-      parsedProps.ref = innerRef
-    }
-
-    return React.createElement(is, parsedProps, children)
-  }
-
-  Component.displayName = 'Box'
-
-  Component.propTypes = {
-    ...propTypes,
-    innerRef: PropTypes.func,
-    is: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
-  }
-
-  Component.defaultProps = {
-    innerRef: null,
-    is: 'div',
-    boxSizing: 'border-box'
-  }
-
-  return Component
+Box.propTypes = {
+  ...propTypes,
+  innerRef: PropTypes.func,
+  is: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
 }
 
-const Box = createComponent({ is: 'div' })
+Box.defaultProps = {
+  innerRef: null,
+  is: 'div',
+  boxSizing: 'border-box'
+}
 
 export default Box

--- a/src/box.tsx
+++ b/src/box.tsx
@@ -22,15 +22,15 @@ function createComponent<T extends Is>({ is: defaultIs }: Options<T>) {
     return React.createElement(is, parsedProps, children)
   }
 
-  ;(Component as any).displayName = 'Box'
+  Component.displayName = 'Box'
 
-  ;(Component as any).propTypes = {
+  Component.propTypes = {
     ...propTypes,
     innerRef: PropTypes.func,
     is: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
   }
 
-  ;(Component as any).defaultProps = {
+  Component.defaultProps = {
     innerRef: null,
     is: 'div',
     boxSizing: 'border-box'

--- a/src/types/box-types.ts
+++ b/src/types/box-types.ts
@@ -45,11 +45,6 @@ export type BoxProps<T extends Is> = InheritedProps<T> &
   }
 
 export interface BoxComponent<T extends Is> {
-  // This is the desired type (inspired by reakit)
-  // <TT extends Is = T>(props: BoxProps<TT>): JSX.Element
-  // Unfortunately, TypeScript doesn't like it. It works for string elements
-  // and functional components without generics, but it breaks on generics.
-  // The following two types are a workaround.
   <TT extends Is = T>(props: BoxProps<TT>): React.ReactElement | null
   propTypes?: any
   defaultProps?: any

--- a/src/types/box-types.ts
+++ b/src/types/box-types.ts
@@ -17,13 +17,13 @@ export type Is<P = any> = React.ElementType<P>
  * Remove box props from object `T` if they're present
  * @template T Object
  */
-export type WithoutBoxProps<T> = Without<T, "is" | "innerRef">
+type WithoutBoxProps<T> = Without<T, "is" | "innerRef">
 
 /**
  * Grab components passed to the `is` prop and return their props
  * @template T Component type
  */
-export type InheritedProps<T extends Is> = WithoutBoxProps<React.ComponentProps<T>>
+type InheritedProps<T extends Is> = WithoutBoxProps<React.ComponentProps<T>>
 
 /**
  * Generic component props with "is" prop
@@ -44,9 +44,9 @@ export type BoxProps<T extends Is> = InheritedProps<T> &
     innerRef?: React.Ref<T>
   }
 
-export interface BoxComponent<T extends Is> {
-  <TT extends Is = T>(props: BoxProps<TT>): React.ReactElement | null
-  propTypes?: any
-  defaultProps?: any
-  displayName?: string
+export interface BoxComponent {
+  <T extends Is>(props: BoxProps<T>): React.ReactElement | null
+  propTypes?: React.FunctionComponent['propTypes']
+  defaultProps?: React.FunctionComponent['defaultProps']
+  displayName?: React.FunctionComponent['displayName']
 }

--- a/src/types/box-types.ts
+++ b/src/types/box-types.ts
@@ -3,9 +3,9 @@ import { EnhancerProps } from './enhancers'
 
 /**
  * @template T Object
- * @template K Union of T keys
+ * @template K Union of keys (not necessarily present in T)
  */
-export type Without<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+export type Without<T, K> = Pick<T, Exclude<keyof T, K>>
 
 /**
  * "is" prop
@@ -14,13 +14,24 @@ export type Without<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 export type Is<P = any> = React.ElementType<P>
 
 /**
+ * Remove box props from object `T` if they're present
+ * @template T Object
+ */
+export type WithoutBoxProps<T> = Without<T, "is" | "innerRef">
+
+/**
+ * Grab components passed to the `is` prop and return their props
+ * @template T Component type
+ */
+export type InheritedProps<T extends Is> = WithoutBoxProps<React.ComponentProps<T>>
+
+/**
  * Generic component props with "is" prop
  * @template P Additional props
  * @template T React component or string element
  */
-export type BoxProps<T extends Is> = &
-  Without<React.ComponentProps<T>, "is"> &
-  EnhancerProps & {
+export type BoxProps<T extends Is> = InheritedProps<T> &
+    EnhancerProps & {
     /**
      * Replaces the underlying element
      */
@@ -39,6 +50,8 @@ export interface BoxComponent<T extends Is> {
   // Unfortunately, TypeScript doesn't like it. It works for string elements
   // and functional components without generics, but it breaks on generics.
   // The following two types are a workaround.
-  <TT extends Is>(props: BoxProps<TT> & { is?: TT }): React.ReactElement | null
-  (props: BoxProps<T>): React.ReactElement | null
+  <TT extends Is = T>(props: BoxProps<TT>): React.ReactElement | null
+  propTypes?: any
+  defaultProps?: any
+  displayName?: string
 }

--- a/src/types/enhancers.ts
+++ b/src/types/enhancers.ts
@@ -141,10 +141,10 @@ type CssProps = Pick<
 type BoxCssProps<CP> = {
   // Enhance the CSS props with the ui-box supported values.
   // `string` isn't added because it'll ruin props with string literal types (e.g textAlign)
-  [P in keyof CP]: CP[P] | number | boolean | null | undefined
+  [P in keyof CP]: CP[P] | number | false | null | undefined
 }
 
-export type BoxPropValue = string | number | boolean | null | undefined
+export type BoxPropValue = string | number | false | null | undefined
 
 export type EnhancerProps = BoxCssProps<CssProps> & {
   /**


### PR DESCRIPTION
I updated a few types to produce slightly better TS errors.

Before:
TS error points to `is` and cryptically says `Type '"button"' is not assignable to type '"div" | undefined'.` which is not the error at all. The error is that there's a prop being used _that's not compatible with `is='button'`. 
<img width="808" alt="Screen Shot 2019-05-31 at 10 38 22 AM" src="https://user-images.githubusercontent.com/710752/58717183-4228a500-8390-11e9-9bcf-971e74c43b65.png">

After:
<img width="818" alt="Screen Shot 2019-05-31 at 10 24 00 AM" src="https://user-images.githubusercontent.com/710752/58717255-6e442600-8390-11e9-9fde-fbf841cdea78.png">
<img width="812" alt="Screen Shot 2019-05-31 at 10 24 07 AM" src="https://user-images.githubusercontent.com/710752/58717254-6e442600-8390-11e9-829a-9077d8920356.png">