### PR TITLE
make innerRef type more forgiving for now

### DIFF
--- a/src/types/box-types.ts
+++ b/src/types/box-types.ts
@@ -41,7 +41,9 @@ export type BoxProps<T extends Is> = InheritedProps<T> &
      * Callback that gets passed a ref to inner DOM node (or component if the
      * `is` prop is set to a React component type).
      */
-    innerRef?: React.Ref<T>
+    innerRef?:
+      | ((instance: any) => void)
+      | React.RefObject<HTMLElement | SVGElement | React.Component>
   }
 
 export interface BoxComponent {


### PR DESCRIPTION
Our `innerRef` typedef doesn't quite work for jsx elements like `is="input"` etc, because it's not translating those into the right type of ref (like `HTMLInputElement`).

@Rowno thoughts on how we could fix this?