### PR TITLE
use React.Ref instead of custom type

### DIFF
--- a/src/types/box-types.ts
+++ b/src/types/box-types.ts
@@ -53,9 +53,7 @@ export type BoxProps<T extends Is> = InheritedProps<T> &
      * Callback that gets passed a ref to inner DOM node (or component if the
      * `is` prop is set to a React component type).
      */
-    innerRef?:
-      | ((ref: RefType<T>) => void)
-      | React.RefObject<RefType<T>>
+    innerRef?: React.Ref<RefType<T>>
   }
 
 export interface BoxComponent {


### PR DESCRIPTION
Turns out React already has a type that covers our bases more fully than what I used.

```ts
type Ref<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"] | RefObject<T> | null;
```