### PR TITLE
Add Box prop-type for "element type"

### DIFF
--- a/src/box.tsx
+++ b/src/box.tsx
@@ -25,7 +25,7 @@ Box.propTypes = {
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.element })
   ]),
-  is: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+  is: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.elementType])
 }
 
 Box.defaultProps = {


### PR DESCRIPTION
From the docs: https://reactjs.org/docs/typechecking-with-proptypes.html
> // A React element type (ie. MyComponent).
  optionalElementType: PropTypes.elementType,

Addresses https://github.com/segmentio/evergreen/issues/681