### PR TITLE
support backwards compat for classnames so we can upgrade evergreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,15 @@ These enhancer groups are also exported. They're all objects with `{ propTypes, 
 * `transform`
 * `transition`
 
+### Classname prefix
+
+By default `ui-box` uses `ub-` as the classname prefix before all ui-box generated classnames. You can alter this by using `setClassNamePrefix('whatever-you-want-')`. Note that the delimiter is included in the prefix... this is to support backwards compatibility with the old classnames (< v3), which you can achieve using something like this:
+
+```js
+import { setClassNamePrefix } from 'ui-box'
+setClassNamePrefix('📦')
+```
+
 ### Server side rendering
 
 To render the styles on the server side just use [`ReactDOMServer.renderToString()`](https://reactjs.org/docs/react-dom-server.html#rendertostring) as usual and then call the [`extractStyles()`](#extractstyles) method retrieve the rendered styles and cache. The styles can then be output to a `<style>` tag or an external stylesheet. The cache data should be passed to the [`hydrate()`](#hydratecache) method on the client side before you call [`ReactDOM.hydrate()`](https://reactjs.org/docs/react-dom.html#hydrate).

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dev": "start-storybook -p 9009",
     "build": "tsc",
     "build-storybook": "build-storybook -s .storybook/static -o .out",
-    "release": "np --no-publish",
+    "release": "np",
     "benchmark": "echo ui-box && react-benchmark tools/benchmarks/box.js",
     "size": "size-limit",
     "coverage": "nyc report --reporter=html"

--- a/src/enhancers/layout.ts
+++ b/src/enhancers/layout.ts
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import getCss from '../get-css'
+import { getClassNamePrefix } from '../get-class-name'
 import { PropEnhancerValueType, PropValidators, PropEnhancers, PropTypesMapping, PropAliases } from '../types/enhancers'
 
 export const propTypes: PropTypesMapping = {
@@ -51,9 +52,9 @@ export const propEnhancers: PropEnhancers = {
   boxSizing: (value: PropEnhancerValueType) => getCss(boxSizing, value),
   clear: (value: PropEnhancerValueType) => getCss(clear, value),
   clearfix: () => ({
-    className: 'ub-clearfix',
+    className: `${getClassNamePrefix()}clearfix`,
     styles: `
-.ub-clearfix:before, .ub-clearfix:after {
+.${getClassNamePrefix()}clearfix:before, .${getClassNamePrefix()}clearfix:after {
   display: table;
   clear: both;
   content: "";

--- a/src/get-class-name.ts
+++ b/src/get-class-name.ts
@@ -1,6 +1,16 @@
 import hash from '@emotion/hash'
 import getSafeValue from './get-safe-value'
 
+let PREFIX = 'ub-'
+
+export function getClassNamePrefix(): string {
+  return PREFIX
+}
+
+export function setClassNamePrefix(prefix: string): void {
+  PREFIX = prefix
+}
+
 export interface PropertyInfo {
   className?: string
   safeValue?: boolean
@@ -35,5 +45,5 @@ export default function getClassName(propertyInfo: PropertyInfo, value: string) 
     valueKey = getSafeValue(value)
   }
 
-  return `ub-${className}_${valueKey}`
+  return `${PREFIX}${className}_${valueKey}`
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import * as styles from './styles'
 export {default} from './box'
 export {default as splitProps} from './utils/split-props'
 export {default as splitBoxProps} from './utils/split-box-props'
+export { setClassNamePrefix } from './get-class-name'
 
 export {
   background,

--- a/test/get-class-name.ts
+++ b/test/get-class-name.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import getClassName from '../src/get-class-name'
+import getClassName, { setClassNamePrefix, getClassNamePrefix } from '../src/get-class-name'
 
 test('supports inherit', t => {
   t.is(getClassName({className: 'w'}, 'inherit'), 'ub-w_inherit')
@@ -37,4 +37,9 @@ test('always hashes values that contain a calc()', t => {
     'calc(50% + 20px)'
   )
   t.is(result, 'ub-w_1vuvdht')
+})
+
+test('allows custom classname prefixes', t => {
+  setClassNamePrefix('📦')
+  t.is(getClassName({className: 'w'}, 'inherit'), '📦w_inherit')
 })


### PR DESCRIPTION
This is an idea to allow consumers to set the classname prefix, which would allow for more graceful upgrading of ui-box without necessarily requiring a major version bump (selector changes might be considered a major breaking change).

This might be overkill. We could consider upgrading ui-box in evergreen, despite the classnames changing – considering that css changes in evergreen also leads to selector changes.