### PR TITLE
Add Box prop-type for "element type" - to v2

### DIFF
--- a/src/box.tsx
+++ b/src/box.tsx
@@ -25,7 +25,7 @@ Box.propTypes = {
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.element })
   ]),
-  is: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+  is: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.elementType])
 }
 
 Box.defaultProps = {


### PR DESCRIPTION
Replicates https://github.com/segmentio/ui-box/pull/51 for v2

From the docs: https://reactjs.org/docs/typechecking-with-proptypes.html
> // A React element type (ie. MyComponent).
  optionalElementType: PropTypes.elementType,

Addresses https://github.com/segmentio/evergreen/issues/681

@mshwery