### PR TITLE
Add plugins

### DIFF
--- a/src/get-css.ts
+++ b/src/get-css.ts
@@ -2,6 +2,7 @@ import prefixer, {Rule} from './prefixer'
 import valueToString from './value-to-string'
 import getClassName, {PropertyInfo} from './get-class-name'
 import { EnhancedProp } from './types/enhancers'
+import { apply as applyPlugins, RuleSet } from './plugins'
 
 /**
  * Generates the class name and styles.
@@ -33,21 +34,30 @@ export default function getCss(propertyInfo: PropertyInfo, value: string | numbe
     rules = [{property: propertyInfo.cssName || '', value: valueString}]
   }
 
-  let styles: string
+  const ruleSet = applyPlugins({
+    selector: `.${className}`,
+    rules
+  })
+
+  const styles = stringifyRuleSet(ruleSet)
+
+  return {className, styles}
+}
+
+function stringifyRuleSet({ selector, rules }: RuleSet): string {
   if (process.env.NODE_ENV === 'production') {
     const rulesString = rules
       .map(rule => `${rule.property}:${rule.value}`)
       .join(';')
-    styles = `.${className}{${rulesString}}`
-  } else {
-    const rulesString = rules
-      .map(rule => `  ${rule.property}: ${rule.value};`)
-      .join('\n')
-    styles = `
-.${className} {
-${rulesString}
-}`
+    return `${selector}{${rulesString}}`
   }
 
-  return {className, styles}
+  const rulesString = rules
+    .map(rule => `  ${rule.property}: ${rule.value};`)
+    .join('\n')
+
+  return `
+${selector} {
+${rulesString}
+}`
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ export { default as splitBoxProps } from './utils/split-box-props'
 export { setClassNamePrefix } from './get-class-name'
 export { configureSafeHref } from './utils/safeHref'
 export { BoxProps, BoxOwnProps, EnhancerProps, PropsOf, PolymorphicBoxProps, BoxComponent } from './types/box-types'
+export { use as usePlugin } from './plugins'
 
 export {
   background,

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,0 +1,28 @@
+import { Rule } from './prefixer'
+
+export interface RuleSet {
+  selector: string,
+  rules: Rule[]
+}
+
+type Plugin = (set: RuleSet) => RuleSet
+
+const plugins: Plugin[] = []
+
+export function use(plugin: Plugin): void {
+  plugins.unshift(plugin)
+}
+
+export function apply(set: RuleSet) {
+  let newSet = {...set}
+
+  for (const plugin of plugins) {
+    newSet = plugin({...newSet})
+  }
+
+  return newSet
+}
+
+export function reset(): void {
+  plugins.length = 0
+}

--- a/test/get-css.ts
+++ b/test/get-css.ts
@@ -1,9 +1,11 @@
 import test from 'ava'
 import getCss from '../src/get-css'
+import * as plugins from '../src/plugins'
 
 const originalNodeEnv = process.env.NODE_ENV
 test.afterEach.always(() => {
   process.env.NODE_ENV = originalNodeEnv
+  plugins.reset()
 })
 
 test('supports basic prop + value', t => {
@@ -57,6 +59,30 @@ test('adds prefixes', t => {
   user-select: none;
 }`
   )
+})
+
+test('applies plugins', t => {
+  const propInfo = {
+    className: 'min-w',
+    cssName: 'min-width',
+    jsName: 'minWidth'
+  }
+
+  plugins.use(({ selector, rules }) => {
+    return {
+      selector: `#my-div ${selector}`,
+      rules
+    }
+  })
+
+  const result = getCss(propInfo, '10px')
+  t.deepEqual(result, {
+    className: 'ub-min-w_10px',
+    styles: `
+#my-div .ub-min-w_10px {
+  min-width: 10px;
+}`
+  })
 })
 
 test.serial('returns minified css in production', t => {

--- a/test/plugins.ts
+++ b/test/plugins.ts
@@ -1,0 +1,30 @@
+import test from 'ava'
+import * as plugins from '../src/plugins'
+
+test.afterEach.always(() => {
+  plugins.reset()
+})
+
+test('applies a selector prefix to the styles', t => {
+  const ruleset = {
+    selector: '.ub-min-w_10px',
+    rules: [
+      { property: 'min-width', value: '10px' },
+      { property: 'user-select', value: 'none' }
+    ]
+  }
+  plugins.use(({ selector, rules }) => {
+    return {
+      selector: `#my-div ${selector}`,
+      rules
+    }
+  })
+  const result = plugins.apply(ruleset)
+  t.deepEqual(result, {
+    selector: '#my-div .ub-min-w_10px',
+    rules: [
+      { property: 'min-width', value: '10px' },
+      { property: 'user-select', value: 'none' }
+    ]
+  })
+})


### PR DESCRIPTION
This change adds a new concept of Plugins to `ui-box` to enable arbitrary userland processing of selectors and styles.

The plugin structure closely resembles that of glamor, which it was inspired by.

In the public API, this change exposes one new function: `usePlugin`.

`usePlugin` takes as its sole argument a function which should accept and return an object with a `selector` property, containing the string selector for a given ruleset, and a `rules` property, containing an array of rules, each with a `property` and `value`.

Plugins are executed in reverse from the order they are added (also from glamor). So if you add plugins `a`, `b`, and then `c`, they will be executed as `c->b->a`.

The motivation for this change is #74. However, given that a plugin system may open up `ui-box` further than desired, I'm happy to open another PR which addresses #74 specifically without a generic plugin.