### PR TITLE
Disable sourcemap generation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
       "dom"
     ],
     "declaration": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "removeComments": true,
     "rootDirs": [
       "./src",


### PR DESCRIPTION
As part of the cleanup for https://github.com/segmentio/evergreen/issues/1454, we're disabling sourcemap generation here. We're not packaging the .ts files alongside, so the sourcemaps are useless anyway.