### PR TITLE
Upgrade TypeScript to 4.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
   "size-limit": [
     {
       "path": "dist/src/index.js",
-      "limit": "55 KB",
+      "limit": "65 KB",
       "running": false,
       "gzip": false
     }

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "sinon": "^7.2.7",
     "size-limit": "^4.5.4",
     "ts-node": "^8.1.0",
-    "typescript": "^3.4.5",
+    "typescript": "4.9.4",
     "webpack": "^4.30.0",
     "xo": "^0.24.0"
   },

--- a/src/utils/split-props.ts
+++ b/src/utils/split-props.ts
@@ -4,7 +4,7 @@ interface Dictionary<T> {
   [key: string]: T
 }
 
-export interface SplitProps<P, K extends keyof P> {
+export interface SplitProps<P extends Dictionary<any>, K extends keyof P> {
   matchedProps: Pick<P, K>
   remainingProps: Omit<P, K>
 }
@@ -12,10 +12,13 @@ export interface SplitProps<P, K extends keyof P> {
 /**
  * Utility to split props based on an array of keys
  */
-export default function splitProps<P extends Dictionary<any>, K extends keyof P>(props: P, keys: K[]): SplitProps<P, K> {
+export default function splitProps<P extends Dictionary<any>, K extends keyof P>(
+  props: P,
+  keys: K[]
+): SplitProps<P, K> {
   const matchedProps = {} as Pick<P, K>
   const remainingProps = {} as P
-  const propKeys= Object.keys(props) as K[]
+  const propKeys = Object.keys(props) as K[]
 
   for (let i = 0; i < propKeys.length; i++) {
     const propKey = propKeys[i]

--- a/src/utils/style-sheet.ts
+++ b/src/utils/style-sheet.ts
@@ -112,7 +112,7 @@ export default class CustomStyleSheet {
       const sheet = this.getSheet()
 
       // This is the ultrafast version, works across browsers
-      if (this.isSpeedy && sheet && sheet.insertRule) {
+      if (this.isSpeedy && sheet != null) {
         this._insert(sheet, rule)
       } else {
         last(this.tags).append(document.createTextNode(rule))

--- a/yarn.lock
+++ b/yarn.lock
@@ -12966,10 +12966,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
+typescript@4.9.4:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 typescript@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
This should be a non-functional change for end-users - looks like the transpiled JS files changed slightly (different helpers/object construction for exports etc), but it shouldn't be a big deal. Bumping up the `size-limit` to account for this.