### PR TITLE
Properly attach nested selectors to CSV parent selector

### DIFF
--- a/src/enhance-props.ts
+++ b/src/enhance-props.ts
@@ -30,8 +30,17 @@ export default function enhanceProps(
     const isSelectorOrChildProp = property === SELECTORS_PROP || parentProperty.length > 0
     // Only attempt to process objects for the `selectors` prop or the individual selectors below it
     if (isObject(value) && isSelectorOrChildProp) {
-      const prop = property === 'selectors' ? '' : property
-      const parsed = enhanceProps(value, noAnd(selectorHead + prop), property)
+      const prop = property === SELECTORS_PROP ? '' : property
+
+      // If the selector head includes a comma, map over selectorHead and attach property for nested selectors so it isn't just added to the last entry
+      // i.e. [aria-current="page"],[aria-selected="true"] + :before -> [aria-current="page"]:before,[aria-selected="true"]:before instead of [aria-current="page"],[aria-selected="true"]:before
+      const newSelectorHead = selectorHead.includes(',')
+        ? selectorHead
+            .split(',')
+            .map(selector => `${selector}${prop}`)
+            .join(',')
+        : `${selectorHead}${prop}`
+      const parsed = enhanceProps(value, noAnd(newSelectorHead), property)
       className = `${className} ${parsed.className}`
       continue
     }

--- a/test/enhance-props.ts
+++ b/test/enhance-props.ts
@@ -171,7 +171,7 @@ test.serial('injects nested selector styles', t => {
   )
 })
 
-test.serial.only('multiple selectors with nested selector are expanded properly', t => {
+test.serial('comma-separated selectors with nested selectors are expanded with nested selector appended to each', t => {
   enhanceProps({
     selectors: {
       '&[aria-current="page"],&[aria-selected="true"]': {
@@ -194,10 +194,10 @@ test.serial.only('multiple selectors with nested selector are expanded properly'
 .ub-color_3366FF_75lazh[aria-current="page"], .ub-color_3366FF_75lazh[aria-selected="true"] {
   color: #3366FF;
 }
-.ub-tfrm_qu4iyp_1d0tz5k[aria-current="page"]:before, .ub-tfrm_qu4iyp_1d0tz5k[aria-selected="true"]:before {
+.ub-tfrm_qu4iyp_fiauus[aria-current="page"]:before, .ub-tfrm_qu4iyp_fiauus[aria-selected="true"]:before {
   transform: scaleY(1);
 }
-.ub-color_2952CC_1tznks7[aria-current="page"]:focus, .ub-color_2952CC_1tznks7[aria-selected="true"]:focus {
+.ub-color_2952CC_drif9m[aria-current="page"]:focus, .ub-color_2952CC_drif9m[aria-selected="true"]:focus {
   color: #2952CC;
 }`
   )

--- a/test/enhance-props.ts
+++ b/test/enhance-props.ts
@@ -170,3 +170,35 @@ test.serial('injects nested selector styles', t => {
 }`
   )
 })
+
+test.serial.only('multiple selectors with nested selector are expanded properly', t => {
+  enhanceProps({
+    selectors: {
+      '&[aria-current="page"],&[aria-selected="true"]': {
+        color: '#3366FF',
+
+        '&:before': {
+          transform: 'scaleY(1)'
+        },
+
+        '&:focus': {
+          color: '#2952CC'
+        }
+      }
+    }
+  })
+
+  t.deepEqual(
+    styles.getAll(),
+    `
+.ub-color_3366FF_75lazh[aria-current="page"], .ub-color_3366FF_75lazh[aria-selected="true"] {
+  color: #3366FF;
+}
+.ub-tfrm_qu4iyp_1d0tz5k[aria-current="page"]:before, .ub-tfrm_qu4iyp_1d0tz5k[aria-selected="true"]:before {
+  transform: scaleY(1);
+}
+.ub-color_2952CC_1tznks7[aria-current="page"]:focus, .ub-color_2952CC_1tznks7[aria-selected="true"]:focus {
+  color: #2952CC;
+}`
+  )
+})


### PR DESCRIPTION
Resolves the issue described in https://github.com/segmentio/evergreen/issues/1622

Essentially, when providing a CSV selector with nested selectors, the nested selectors would only be added once to the end of the parent selector string, whereas we would expect the csv to be expanded and each individual selector has the nested one appended.


```tsx
<Box
  selectors={{
    '&[aria-current="page"],&[aria-selected="true"]': {
      "&:before": {
        transform: "scaleY(1)",
      },
    },
  }}
/>
```


```diff
-.ub-tfrm_qu4iyp_fiauus[aria-current="page"], .ub-tfrm_qu4iyp_fiauus[aria-selected="true"]:before {
+.ub-tfrm_qu4iyp_fiauus[aria-current="page"]:before, .ub-tfrm_qu4iyp_fiauus[aria-selected="true"]:before {
  transform: scaleY(1);
}
```